### PR TITLE
更新藍新網址

### DIFF
--- a/src/Spgateway.php
+++ b/src/Spgateway.php
@@ -298,10 +298,10 @@ SCRTPT;
 	{
 		if ($this->test)
 		{
-			return 'https://ccore.spgateway.com/MPG/mpg_gateway';
+			return 'https://ccore.newebpay.com/MPG/mpg_gateway';
 		}
 
-		return 'https://core.spgateway.com/MPG/mpg_gateway';
+		return 'https://core.newebpay.com/MPG/mpg_gateway';
 	}
 
 	/**


### PR DESCRIPTION
@asika32764 你好
由於藍新網址將在明年棄用 spgateway.com ，此PR內容為更新有使用到藍新舊有網域的網址至新網域 newebpay.com
有關藍新網址更改細節請見[藍新官網公告](https://www.newebpay.com/info/news/news_detail?post_data=166b529ac2a24b5632af474c36ecbc3dd057c05c27f55262c27fbf96d7bfd165)，謝謝